### PR TITLE
Add Icon Label on `Advisor.Button`

### DIFF
--- a/lua/advisor-modules/ui/menu/cl_advisor_home.lua
+++ b/lua/advisor-modules/ui/menu/cl_advisor_home.lua
@@ -16,12 +16,14 @@ function PANEL:Init()
 
     local discordButton = self.ButtonLayout:Add("Advisor.Button")
     discordButton:SetText("Join Discord")
+    discordButton:SetIcon(0xf0c1)
     function discordButton:DoClick()
         gui.OpenURL("https://discord.gg/gca")
     end
 
     local githubButton = self.ButtonLayout:Add("Advisor.Button")
     githubButton:SetText("GitHub")
+    githubButton:SetIcon(0xf0c1)
     function githubButton:DoClick()
         gui.OpenURL(Advisor.RepositoryURL)
     end

--- a/lua/advisor-modules/ui/vgui/cl_advisor_button.lua
+++ b/lua/advisor-modules/ui/vgui/cl_advisor_button.lua
@@ -19,13 +19,26 @@ function PANEL:Init()
     self:SetMouseInputEnabled(true)
 
     self.DisplayText = vgui.Create("DLabel", self)
-    self.DisplayText:Dock(FILL)
-    self.DisplayText:DockMargin(8, 8, 8, 8) // TODO: Check responsive issues with left and right margin
     self.DisplayText:SetContentAlignment(5)
     self.DisplayText:SetFont("Advisor:Rubik.Button")
 
+    self.IconText = vgui.Create("DLabel", self)
+    self.IconText:SetText( "" )
+    self.IconText:SetFont("Advisor:Awesome")
+    self.IconText:SetContentAlignment(5)
+
     self:SetText("Button")
     self:SetHeight(32)
+end
+
+function PANEL:PerformLayout(w, h)
+    local icon_width = 0
+    if ( #self:GetIcon() > 0 ) then
+        icon_width = self.IconText:GetWide() + Advisor.Theme.Button.IconMargin
+        self.IconText:SetPos( w / 2 - ( icon_width + self.DisplayText:GetWide() ) / 2, h / 2 - self.IconText:GetTall() / 2 )    
+    end
+
+    self.DisplayText:SetPos( w / 2 - ( self.DisplayText:GetWide() - icon_width ) / 2, h / 2 - self.DisplayText:GetTall() / 2 )
 end
 
 function PANEL:Paint(w, h)
@@ -56,6 +69,20 @@ end
 function PANEL:SetText(text)
     self.DisplayText:SetText(text)
     self.DisplayText:SizeToContentsX()
+end
+
+function PANEL:GetIcon()
+    return self.IconText:GetText()
+end
+
+function PANEL:SetIcon(...)
+    local icon = utf8.char(...)
+    if not ... then 
+        icon = utf8.char(0xf138) -- Default to chevron with right arrow
+    end
+
+    self.IconText:SetText(icon)
+    self.IconText:SizeToContentsX()
 end
 
 function PANEL:OnMousePressed()

--- a/lua/advisor-modules/ui/vgui/cl_advisor_button.lua
+++ b/lua/advisor-modules/ui/vgui/cl_advisor_button.lua
@@ -33,7 +33,7 @@ end
 
 function PANEL:PerformLayout(w, h)
     local icon_width = 0
-    if ( #self:GetIcon() > 0 ) then
+    if #self:GetIcon() > 0 then
         icon_width = self.IconText:GetWide() + Advisor.Theme.Button.IconMargin
         self.IconText:SetPos( w / 2 - ( icon_width + self.DisplayText:GetWide() ) / 2, h / 2 - self.IconText:GetTall() / 2 )    
     end

--- a/lua/advisor-modules/ui/vgui/theme/cl_theme.lua
+++ b/lua/advisor-modules/ui/vgui/theme/cl_theme.lua
@@ -69,6 +69,8 @@ Advisor.Theme.Button =
     RoundedCorners = { true, true, true, true },
     -- Radius of the rounded corners on buttons. Set to 0 to disable.
     CornerRadius = 4,
+    -- Space between the Icon and the Text on buttons.
+    IconMargin = 4,
 
     -- Default colors for buttons.
     Default = 


### PR DESCRIPTION
Resolves #5

Added an optional icon to `Advisor.Button` :
![image](https://user-images.githubusercontent.com/33220603/137553983-66d5183d-8c6c-4a69-bf1e-29022b920750.png)
