### PR TITLE
Fix moduleloader not displaying current folder

### DIFF
--- a/lua/advisor-modules/logging/module_logging.lua
+++ b/lua/advisor-modules/logging/module_logging.lua
@@ -4,7 +4,7 @@ local tbl =
     description = "Logging library used to log messages to the console and other outputs.",
     loadOrder = 
     {
-        "meta",
+        "meta/",
         "sh_log.lua",
         "sh_log_globals.lua"
     }

--- a/lua/advisor/moduleloader.lua
+++ b/lua/advisor/moduleloader.lua
@@ -216,7 +216,10 @@ local function LoadModule(moduleName, numRecursions)
                 local files, dirs = file.Find(loadPath .. "/*", "LUA")
 
                 -- If already loaded, hecc off.
-                if Advisor.Modules.LoadedDirectories[fileModulePath] then continue end
+                if Advisor.Modules.LoadedDirectories[fileModulePath .. "/"] then continue end
+                
+                -- Avoid reloading the directory
+                Advisor.Modules.LoadedDirectories[fileModulePath .. "/"] = true
 
                 -- TODO: Check that we still have things to load here (i.e. haven't been loaded via loadOrder yet)
                 local loadRecSpace = string.rep(" ", (numRecursions + 1) * 2)
@@ -251,13 +254,17 @@ local function LoadModule(moduleName, numRecursions)
                 end
             end
         end
+    else
+        -- Print current folder
+        local loadRecSpace = string.rep(" ", numRecursions * 2)
+        print(loadRecSpace .. "[" .. moduleName .. "/" .. "]")
     end
 
     -- Load other files in current directory.
     for _, f in pairs(moduleFiles) do
         local fi = string.lower(f) 
         local moduleFile = "module_" .. moduleName .. ".lua"
-        if string.EndsWith(fi, ".lua") && fi != moduleFile  then 
+        if string.EndsWith(fi, ".lua") && fi != moduleFile then 
             RealmInclude(modulePath, fi, recSpace)
         end 
     end 


### PR DESCRIPTION
Resolves #20

Also added a '/' to `loadOrder` of 'meta' at `module_logging.lua` to have a uniform printing.

Screenshot to compare with issue's one :
![image](https://user-images.githubusercontent.com/33220603/137583146-040ca3c5-aa18-4076-b53e-cd7befbc2d46.png)
