### PR TITLE
Generate Flavor Text on Menu Opening

### DIFF
--- a/lua/advisor-modules/ui/main/cl_main.lua
+++ b/lua/advisor-modules/ui/main/cl_main.lua
@@ -4,7 +4,13 @@ Advisor.UI.MainPanel = Advisor.UI.MainPanel or nil
 
 local function ResetMenu()
     if IsValid(Advisor.UI.MainPanel) then
+        local was_visible = Advisor.UI.MainPanel:IsVisible()
         Advisor.UI.MainPanel:Remove()
+
+        -- Re-open the menu if it was visible before 
+        if was_visible then
+            Advisor.UI.OpenMenu()
+        end
     end
 end
 concommand.Add("advisor_refreshmenu", ResetMenu, nil, "Removes Advisor's menu to allow for re-creation.")
@@ -17,7 +23,6 @@ function Advisor.UI.OpenMenu()
             Advisor.UI.MainPanel:Close()
         else
             Advisor.UI.MainPanel:Open()
-            Advisor.UI.MainPanel:SlideDown(0.5)
         end
         return
     end
@@ -37,7 +42,7 @@ function Advisor.UI.OpenMenu()
     local main = vgui.Create("Advisor.Menu")
     main:PopulateOptions(mp)
     main:MakePopup()
-    main:SlideDown(0.5)
+    main:Open()
 
     Advisor.UI.MainPanel = main
 end

--- a/lua/advisor-modules/ui/vgui/cl_advisor_menu.lua
+++ b/lua/advisor-modules/ui/vgui/cl_advisor_menu.lua
@@ -1,13 +1,7 @@
 local PANEL = {}
 
 function PANEL:Init()
-    local title = "Advisor"
-    
-    if #Advisor.Theme.FlavorText ~= 0 then
-        title = title .. " - " .. Advisor.Theme.FlavorText[math.random(#Advisor.Theme.FlavorText)]
-    end
-
-    self:SetTitle(title)
+    self:SetTitle("Advisor")
     self:SetSize(ScrW() * 0.6, ScrH() * 0.6)
     self:SetMinWidth(ScrW() * 0.6)
     self:SetMinHeight(ScrH() * 0.6)
@@ -31,6 +25,23 @@ function PANEL:PopulateOptions(mp)
             self.Categories:AddOption(option.Name, option.Panel, option.Icon and unpack(option.Icon) or nil)
         end
     end
+end
+
+function PANEL:GenerateFlavorText()
+    local title = string.Split(self:GetTitle(), "-")[1] -- Retrieve the title without the flavor text
+    title = string.TrimRight(title) -- Remove right spaces
+    
+    if #Advisor.Theme.FlavorText ~= 0 then
+        title = title .. " - " .. Advisor.Theme.FlavorText[math.random(#Advisor.Theme.FlavorText)]
+    end
+
+    self:SetTitle(title)
+end
+
+function PANEL:OnOpen()
+    self:GenerateFlavorText()
+
+    self:SlideDown(0.5)
 end
 
 vgui.Register("Advisor.Menu", PANEL, "Advisor.Window")


### PR DESCRIPTION
Also :
+ Opening the Menu now SlideDown automatically (without calling the function)
+ `advisor_refreshmenu` now re-open the menu if it was visible before the deletion