### PR TITLE
Fix version checking

### DIFF
--- a/lua/advisor-modules/framework/version/sh_versioncheck.lua
+++ b/lua/advisor-modules/framework/version/sh_versioncheck.lua
@@ -65,7 +65,6 @@ local function CheckAdvisorVersion()
         http.Fetch(Advisor.VersionFile, OnSuccess, OnFailure)    
     end
 end
-CheckAdvisorVersion()
 
 if CLIENT then
     hook.Add("InitPostEntity", "Advisor.VersionCheck", CheckAdvisorVersion)

--- a/lua/advisor-modules/framework/version/sh_versioncheck.lua
+++ b/lua/advisor-modules/framework/version/sh_versioncheck.lua
@@ -35,6 +35,8 @@ local function OnSuccess(body, size, headers, httpCode)
             if localVersion[i] < remoteVersion[i] then
                 Advisor.UpToDate = false
                 break
+            elseif localVersion[i] > remoteVersion[i] then
+                break
             end
         end
     end


### PR DESCRIPTION
This resolves the bug where a local version with more numbers in it than the remote version would be considered as up to date (e.g.: local version = `1.0.10` and remote version = `2.0.0`)