### PR TITLE
Added TimeParser for Commands Arguments

### DIFF
--- a/lua/advisor-modules/commands/parsers/sh_time_parser.lua
+++ b/lua/advisor-modules/commands/parsers/sh_time_parser.lua
@@ -1,0 +1,71 @@
+local TimeParser = {}
+
+local converter = {}
+converter.s = 1
+converter.m = 60
+converter.h = converter.m * 60
+converter.d = converter.h * 24
+converter.w = converter.d * 7
+converter.mo = converter.d * 30
+converter.y = converter.d * 365
+
+function TimeParser:Parse(ctx, raw)
+    if raw:Trim() == "" then
+        return false, { namespace = "parsers", key = "empty_string" }    
+    end
+
+    -- Initialize time
+    local parsedTime = 0
+
+    -- Convert given time
+    local isConvertingNumber = true
+    local amount, converterType = "", ""
+    for i = 1, #raw do
+        local letter = raw:sub( i, i )
+        
+        local number = tonumber( letter )
+        -- Append number to amount
+        if number then
+            -- Add current parsed time
+            if not isConvertingNumber then
+                number = tonumber( amount )
+                if converter[converterType] then
+                    parsedTime = parsedTime + number * converter[converterType]
+                else
+                    return false, { namespace = "parsers", key = "no_time_converter", args = { converterType } }
+                end
+
+                amount, converterType = "", ""
+            end
+
+            amount = amount .. letter
+            isConvertingNumber = true
+        -- Append letter to converter type
+        else
+            converterType = converterType .. letter
+            isConvertingNumber = false
+        end
+    end
+
+    -- Convert remaining time
+    if #amount > 0 then
+        local number = tonumber( amount )
+        if #converterType > 0 then
+            if converter[converterType] then
+                parsedTime = parsedTime + number * converter[converterType]
+            else
+                return false, { namespace = "parsers", key = "no_time_converter", args = { converterType } }
+            end
+        else
+            -- Convert to seconds
+            parsedTime = parsedTime + number
+        end
+    elseif #converterType > 0 then
+        return false, { namespace = "parsers", key = "no_time_amount", args = { converterType } }
+    end
+
+    return true, parsedTime
+end
+
+Advisor.CommandHandler.RegisterParser("time", TimeParser)
+Advisor.CommandHandler.RegisterParser("duration", TimeParser)

--- a/lua/advisor-modules/commands/parsers/sh_time_parser.lua
+++ b/lua/advisor-modules/commands/parsers/sh_time_parser.lua
@@ -61,7 +61,7 @@ function TimeParser:Parse(ctx, raw)
             parsedTime = parsedTime + number
         end
     elseif #converterType > 0 then
-        return false, { namespace = "parsers", key = "no_time_amount", args = { converterType } }
+        return false, { namespace = "parsers", key = "no_time_amount" }
     end
 
     return true, parsedTime

--- a/lua/advisor-modules/commands/sh_testcommand.lua
+++ b/lua/advisor-modules/commands/sh_testcommand.lua
@@ -32,3 +32,20 @@ menuCmd.Callback = function(ctx)
     if not IsValid(ctx:GetSender()) then return end
     Advisor.UI.ClientOpenMenu(ctx:GetSender())
 end
+
+local clockCmd = Advisor.CommandHandler.RegisterCommand("Advisor", "clock", "Show the current date and time. Can handle additional time.")
+clockCmd:AddOptionalArgument("add_time", "time", 0)
+clockCmd.Callback = function(ctx, time)
+    local totalTime = os.time() + time
+    local dateText = os.date("%d/%m/%Y - %H:%M:%S", totalTime)
+    if time > 0 then
+        dateText = os.date("%d/%m/%Y - %H:%M:%S") .. " => " .. dateText
+    end
+
+    local ply = ctx:GetSender()
+    if not IsValid(ply) then
+        print(dateText)
+    else
+        PrintMessage(HUD_PRINTTALK, dateText)
+    end
+end

--- a/lua/advisor-modules/localization/sh_loc_english.lua
+++ b/lua/advisor-modules/localization/sh_loc_english.lua
@@ -48,6 +48,8 @@ Language("english")
         Key("self_is_console", "You cannot target yourself on the console.")
         Key("no_target", "Could not find any target.")
         Key("ambiguous_target", "Found multiple targets from the given name, please try again with a more accurate one.")
+        Key("no_time_converter", "Could not find the time converter for '%s'.")
+        Key("no_time_amount", "Could not find the time amount to convert.")
     EndNamespace()
 
     Namespace("commands")

--- a/lua/advisor-modules/localization/sh_loc_english.lua
+++ b/lua/advisor-modules/localization/sh_loc_english.lua
@@ -48,7 +48,7 @@ Language("english")
         Key("self_is_console", "You cannot target yourself on the console.")
         Key("no_target", "Could not find any target.")
         Key("ambiguous_target", "Found multiple targets from the given name, please try again with a more accurate one.")
-        Key("no_time_converter", "Could not find the time converter for '%s'.")
+        Key("no_time_converter", "Could not convert '%s' into a valid time unit (valid units are (s)econds, (m)inutes, (h)ours, (d)ays, (w)eeks, (mo)nths and (y)ears).")
         Key("no_time_amount", "Could not find the time amount to convert.")
     EndNamespace()
 

--- a/lua/advisor-modules/localization/sh_loc_french.lua
+++ b/lua/advisor-modules/localization/sh_loc_french.lua
@@ -36,6 +36,8 @@ Language("french")
         Key("self_is_console", "Vous ne pouvez pas vous cibler sur la console.")
         Key("no_target", "Impossible de trouver une cible.")
         Key("ambiguous_target", "Plusieurs cibles correspondent au nom donné, veuillez ré-essayer avec un nom plus précis.")
+        Key("no_time_converter", "Impossible de convertir '%s' en temps.")
+        Key("no_time_amount", "Impossible de trouver le temps à convertir.")
     EndNamespace()
 
     Namespace("commands")

--- a/lua/advisor-modules/localization/sh_loc_french.lua
+++ b/lua/advisor-modules/localization/sh_loc_french.lua
@@ -36,7 +36,7 @@ Language("french")
         Key("self_is_console", "Vous ne pouvez pas vous cibler sur la console.")
         Key("no_target", "Impossible de trouver une cible.")
         Key("ambiguous_target", "Plusieurs cibles correspondent au nom donné, veuillez ré-essayer avec un nom plus précis.")
-        Key("no_time_converter", "Impossible de convertir '%s' en temps.")
+        Key("no_time_converter", "Impossible de convertir '%s' dans une unité de temps valide (parmis les (s)econdes, (m)inutes, (h)eures, (d) jours, (w) semaines, (mo)is et les (y) années).")
         Key("no_time_amount", "Impossible de trouver le temps à convertir.")
     EndNamespace()
 

--- a/lua/advisor-modules/utils/sv_helpers.lua
+++ b/lua/advisor-modules/utils/sv_helpers.lua
@@ -4,7 +4,7 @@ Advisor.Utils = Advisor.Utils or {}
 util.AddNetworkString("Advisor.LocalizedMessage")
 
 function Advisor.Utils.LocalizedMessage(ply, color, namespace, key, ...)
-    local args = unpack({ ... }) or {}
+    local args = { ... }
 
     -- Could be an attempt to send to the console, ignoring.
     if not istable(ply) and not (IsValid(ply) and ply:IsPlayer()) then


### PR DESCRIPTION
Resolves #26

TimeParser returns a number : the specified time in seconds by converting each time unit (see lines 3 to 10 of `sh_time_parser.lua`). The specified time can be just a number (in seconds; which will be returned) or a series of time units with their amounts.
Examples with the command `clock`:
![image](https://user-images.githubusercontent.com/33220603/137624909-de7ff061-a4df-40c3-8ca4-86f78598c23a.png)


Also fixed `Advisor.Utils.LocalizedMessage` throwing error while iterating on `args` which was not a table