### PR TITLE
Fix errors & incorrect missing argument w/ Command Handler

### DIFF
--- a/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
+++ b/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
@@ -24,7 +24,7 @@ function Advisor.CommandHandler.RunCommand(sender, raw, cmd, args)
 
     -- Check that we have enough arguments to satisfy the command's request.
     if #args < cmd:GetRequiredAmount() then
-        local missingArg = cmdArgs[#args]
+        local missingArg = cmdArgs[math.max( 1, #args )]
         Advisor.Utils.LocalizedMessage(sender, Color(255, 185, 0), "commands", "missing_argument", missingArg:GetName())
         return ""
     end

--- a/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
+++ b/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
@@ -76,7 +76,7 @@ function Advisor.CommandHandler.RunCommand(sender, raw, cmd, args)
     if success then return "" end
 
     Advisor.Log.Error(LogCommands, "An error has occured while executing command '%s': %s", cmd:GetName(), errorMsg)
-    Advisor.Utils.LocalizedMessage(sender, Color(255, 90, 90), "commands", "error_thrown", { cmd:GetName(), errorMsg } )
+    Advisor.Utils.LocalizedMessage(sender, Color(255, 90, 90), "commands", "error_thrown", cmd:GetName(), errorMsg )
 end
 
 function Advisor.CommandHandler.OnPlayerMessage(sender, text, teamChat)

--- a/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
+++ b/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
@@ -24,7 +24,7 @@ function Advisor.CommandHandler.RunCommand(sender, raw, cmd, args)
 
     -- Check that we have enough arguments to satisfy the command's request.
     if #args < cmd:GetRequiredAmount() then
-        local missingArg = cmdArgs[math.max( 1, #args )]
+        local missingArg = cmdArgs[#args + 1]
         Advisor.Utils.LocalizedMessage(sender, Color(255, 185, 0), "commands", "missing_argument", missingArg:GetName())
         return ""
     end

--- a/lua/advisor-modules/utils/sh_helpers.lua
+++ b/lua/advisor-modules/utils/sh_helpers.lua
@@ -42,6 +42,8 @@ end
 
 function Advisor.Utils.ToStringArray(text)
     text = string.Trim(text)
+    if #text == 0 then return {} end
+
     local args = {}
     local currentArg = ""
 


### PR DESCRIPTION
Fixes an error concerning missing argument & an incorrect missing argument message when running a command in the console

Basically, assuming a command requiring 2 arguments, the issue was that when:
- running the command in the **console** with the 1st argument specified, it returned a `missing_argument` message concerning the 1st argument instead of the 2nd
- running the command in the **tchat** with no argument specified returned an index error because `missingArg == nil` (since `#args == 0` instead of `1`)