### PR TITLE
Add a default value to parser & Fix multiple optional arguments returning an error

### DIFF
--- a/lua/advisor-modules/commands/parsers/sh_player_parser.lua
+++ b/lua/advisor-modules/commands/parsers/sh_player_parser.lua
@@ -134,4 +134,8 @@ function PlayerParser:Autocomplete(arg, rawArg)
     return found
 end
 
+function PlayerParser:GetDefault(ctx)
+    return {{ steamid = ctx.sender:SteamID64(), ply = ctx.sender }}
+end
+
 Advisor.CommandHandler.RegisterParser("player", PlayerParser)

--- a/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
+++ b/lua/advisor-modules/framework/commandhandler/sv_commandhandler.lua
@@ -51,7 +51,11 @@ function Advisor.CommandHandler.RunCommand(sender, raw, cmd, args)
 
             parsedArgs[#parsedArgs + 1] = result
         elseif arg:GetOptional() then
-            parsedArgs[#parsedArgs + 1] = arg:GetDefault()
+            local default = arg:GetDefault()
+            if default == nil or default == NULL then
+                default = parser:GetDefault(ctx)
+            end
+            parsedArgs[#parsedArgs + 1] = default
         else
             Advisor.Utils.LocalizedMessage(sender, Color(255, 185, 0), "commands", "missing_argument", arg:GetName())
             return ""

--- a/lua/advisor-modules/framework/meta/sh_argumentparser.lua
+++ b/lua/advisor-modules/framework/meta/sh_argumentparser.lua
@@ -22,3 +22,12 @@ function Advisor.ArgumentParser:Autocomplete(cmdArg, rawArg)
 
     return {}
 end
+
+--[[ 
+    Get the default value when the Argument is set as optional without a set default value
+    @param ctx The context of the command being executed.
+    @returns Value (any)
+--]]
+function Advisor.ArgumentParser:GetDefault(ctx)
+    return nil
+end

--- a/lua/advisor-modules/framework/meta/sh_command.lua
+++ b/lua/advisor-modules/framework/meta/sh_command.lua
@@ -86,7 +86,7 @@ function Advisor.Command:AddOptionalArgument(name, argType, default, description
     end
 
     -- Check that there is no remainder argument before this one, as this is illegal.
-    if #self.arguments > 0 and self.arguments[#self.arguments]:GetOptional() then
+    if #self.arguments > 0 and self.arguments[#self.arguments]:GetRemainder() then
         ErrorNoHaltWithStack(string.format("Cannot add an optional argument after a remainder one."))
         return
     end


### PR DESCRIPTION
As we can't set a default value to a player argument and as I wanted to not having to handle it in each command, I have made a default method on the parser to handle that, which returns the 'command sender'. I'm not sure if it's a correct way to do this though, it could be an issue if you really want a nullable argument in your command callback for some reasons (maybe we can add an additional parameter to prevent the parser default's method from running).

Also fixes the remainder error which was triggerred by an optional argument on the `AddOptionalArgument` method